### PR TITLE
docs: add npx skills installation guide and fix YAML frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,36 +19,99 @@ Complete preparation workflow before pushing staged files to a feature branch.
 - GitHub issue creation
 - Feature branch setup with proper naming
 - Proper commit formatting (feat/fix types with issue references, no Co-Authored-By)
-- **Automatic push to GitHub** when all quality gates pass
+- Automatic push to GitHub when all quality gates pass
 - GitHub-only pushes (verifies remote is GitHub.com)
 
-**Usage:**
-When you have staged files ready to push, Claude will automatically invoke this skill via description matching.
+### sync-req
+
+Generate ISO/IEC/IEEE 29148:2018 compliant software requirements from code implementation or manual entry.
+
+**Features:**
+- Reverse engineering: Extract requirements from code
+- Forward engineering: Create requirements from scratch
+- Multi-format output: Markdown, Excel, DOORS-compatible CSV
+- Multi-language support: Python, JavaScript/TypeScript, Go, Java, C/C++
 
 ## Installation
 
-### For Claude Code
+### Using npx skills (Recommended)
+
+Install skills directly into your project:
+
+```bash
+# Install all skills from this repository
+npx skills install github:melodypapa/uncertainty
+
+# Or install specific skills
+npx skills install github:melodypapa/uncertainty --skills github-workflow
+npx skills install github:melodypapa/uncertainty --skills sync-req
+```
+
+### Manual Installation
 
 Copy skills to your project:
 
 ```bash
-cp -r skills/github-workflow /path/to/your/project/skills/
+# Clone the repository
+git clone https://github.com/melodypapa/uncertainty.git
+
+# Copy specific skills to your project
+cp -r uncertainty/skills/github-workflow /path/to/your/project/skills/
+cp -r uncertainty/skills/sync-req /path/to/your/project/skills/
 ```
 
-Or use as a reference to create project-specific skills.
+### Verify Installation
+
+```bash
+# List installed skills
+npx skills list
+
+# Check skill details
+npx skills show github-workflow
+npx skills show sync-req
+```
 
 ## Skill Structure
 
 ```
 skills/
 ├── README.md
-└── github-workflow/
-    └── SKILL.md
+├── github-workflow/
+│   ├── SKILL.md           # Main skill definition
+│   └── evals.json         # Test cases and assertions
+└── sync-req/
+    ├── SKILL.md           # Main skill definition
+    ├── evals.json         # Test cases and assertions
+    ├── iso-29148.md       # ISO standard reference
+    ├── requirements.md    # Requirements template
+    └── doors-csv-format.md # DOORS import format
 ```
 
 Each skill is a self-contained directory with:
-- `SKILL.md` - Main reference document with frontmatter
-- Supporting files (if needed)
+- `SKILL.md` - Main reference document with frontmatter (required)
+- `evals.json` - Test cases for verification
+- Supporting files (reference docs, templates)
+
+## Usage
+
+Skills are automatically invoked by Claude Code based on their descriptions:
+
+- **github-workflow**: Triggers when you have staged files ready to push, need pre-push quality checks, or ask about committing/pushing to GitHub
+- **sync-req**: Triggers when you need to create requirements specifications, document what code implements, or generate DOORS import files
+
+## Development
+
+### Testing Skills
+
+```bash
+# Run skill evaluations
+cd skills/github-workflow
+python github-workflow-workspace/iteration-6/verify_evals.py
+```
+
+### Creating New Skills
+
+See [skills/README.md](skills/README.md) for the complete guide on creating skills following TDD methodology.
 
 ## License
 
@@ -57,3 +120,8 @@ MIT License - see [LICENSE](LICENSE)
 ## Contributing
 
 Contributions welcome! Ensure skills are tested with subagents before submitting.
+
+## Resources
+
+- [Skill Specification](https://agentskills.io/specification)
+- [Claude Code Documentation](https://docs.anthropic.com/claude-code)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "uncertainty-skills",
+  "version": "1.0.0",
+  "description": "A collection of reusable skills for Claude Code automation workflows",
+  "keywords": [
+    "claude",
+    "claude-code",
+    "skills",
+    "github-workflow",
+    "sync-req",
+    "requirements",
+    "automation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/melodypapa/uncertainty.git"
+  },
+  "author": "melodypapa",
+  "license": "MIT"
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,6 +2,60 @@
 
 This directory contains custom skills for Claude Code.
 
+## Available Skills
+
+### github-workflow
+
+Complete preparation workflow before pushing staged files to a feature branch.
+
+**Features:**
+- Quality gates (language-specific: ruff/mypy/pytest for Python, ESLint/Prettier/Jest for JS/TS, go fmt/go vet/go test for Go, Maven/Gradle test for Java, clang-format/clang-tidy for C/C++)
+- Auto-detects project type and source directories
+- GitHub issue creation
+- Feature branch setup with proper naming
+- Proper commit formatting (feat/fix types with issue references, no Co-Authored-By)
+- Automatic push to GitHub when all checks pass
+
+**Usage:**
+When you have staged files ready to push, Claude will automatically invoke this skill via description matching.
+
+### sync-req
+
+Generate ISO/IEC/IEEE 29148:2018 compliant software requirements from code implementation or manual entry.
+
+**Features:**
+- Reverse engineering: Extract requirements from code
+- Forward engineering: Create requirements from scratch
+- Multi-format output: Markdown, Excel, DOORS-compatible CSV
+- Multi-language support: Python, JavaScript/TypeScript, Go, Java, C/C++
+
+**Usage:**
+When you need to create requirements specifications, document what code implements, or generate DOORS import files, Claude will automatically invoke this skill.
+
+## Installation
+
+### Using npx skills (Recommended)
+
+```bash
+# Install all skills from this repository
+npx skills install github:melodypapa/uncertainty
+
+# Or install specific skills
+npx skills install github:melodypapa/uncertainty --skills github-workflow
+npx skills install github:melodypapa/uncertainty --skills sync-req
+```
+
+### Verify Installation
+
+```bash
+# List installed skills
+npx skills list
+
+# Check skill details
+npx skills show github-workflow
+npx skills show sync-req
+```
+
 ## How to Create a Skill
 
 **IMPORTANT: Follow the TDD process - test before writing!**
@@ -101,33 +155,3 @@ Run `/superpowers:writing-skills` for complete documentation on skill creation i
 - Skill spec: https://agentskills.io/specification
 - Test methodology: @superpowers/marketplace/superpowers/5.0.6/skills/writing-skills/testing-skills-with-subagents.md
 - Graphviz conventions: @superpowers/marketplace/superpowers/5.0.6/skills/writing-skills/graphviz-conventions.dot
-
-## Available Skills
-
-### github-workflow
-
-Complete preparation workflow before pushing staged files to a feature branch.
-
-**Features:**
-- Quality gates (language-specific: ruff/mypy/pytest for Python, ESLint/Prettier/Jest for JS/TS, go fmt/go vet/go test for Go, Maven/Gradle test for Java, clang-format/clang-tidy for C/C++)
-- Auto-detects project type and source directories
-- GitHub issue creation
-- Feature branch setup with proper naming
-- Proper commit formatting (feat/fix types with issue references, no Co-Authored-By)
-- Automatic push to GitHub when all checks pass
-
-**Usage:**
-When you have staged files ready to push, Claude will automatically invoke this skill via description matching.
-
-### sync-req
-
-Generate ISO/IEC/IEEE 29148:2018 compliant software requirements from code implementation or manual entry.
-
-**Features:**
-- Reverse engineering: Extract requirements from code
-- Forward engineering: Create requirements from scratch
-- Multi-format output: Markdown, Excel, DOORS-compatible CSV
-- Multi-language support: Python, JavaScript/TypeScript, Go, Java, C/C++
-
-**Usage:**
-When you need to create requirements specifications, document what code implements, or generate DOORS import files, Claude will automatically invoke this skill.

--- a/skills/github-workflow/SKILL.md
+++ b/skills/github-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-workflow
-description: Use when user has staged files ready to push to a feature branch, needs to run pre-push quality checks, asks what to do before pushing staged changes, or mentions committing/pushing code to GitHub. Triggers on keywords: staged, commit, push, branch, PR, pull request, quality gates, pre-push checks.
+description: "Use when user has staged files ready to push to a feature branch, needs to run pre-push quality checks, asks what to do before pushing staged changes, or mentions committing/pushing code to GitHub. Triggers on keywords: staged, commit, push, branch, PR, pull request, quality gates, pre-push checks."
 ---
 
 # GitHub Workflow


### PR DESCRIPTION
Closes #18

## Summary
- Add npx skills installation guide to README.md
- Add package.json for NPM package metadata
- Reorganize skills/README.md with installation section
- Fix github-workflow SKILL.md YAML frontmatter (quote description)

## Root Cause
The github-workflow SKILL.md description contained a colon in the text which YAML interpreted as a key-value separator, causing the frontmatter parsing to fail.

## Fix
Added double quotes around the description value in the YAML frontmatter.