### PR TITLE
docs: improve req-traceability skill documentation and eval assertions

### DIFF
--- a/skills/req-traceability/SKILL.md
+++ b/skills/req-traceability/SKILL.md
@@ -5,7 +5,7 @@ author: melodypapa
 license: MIT
 repository: https://github.com/melodypapa/uncertainty
 keywords: [requirements, traceability, iso-29148, iso-29119-4, test-design, test-cases, coverage, documentation]
-version: "1.2.1"
+version: "1.2.2"
 spec-version: "1.0.0"
 ---
 
@@ -79,6 +79,61 @@ Create and maintain ISO/IEC/IEEE 29148 compliant requirements that serve as a **
 | `Coverage Matrix` | Table mapping requirements to test cases |
 | `Coverage Percentage` | Percentage of requirements with test coverage |
 | `Traces-To` | Field linking test case to requirement |
+
+## Output Structure
+
+**Default output locations:**
+
+| Output Type | Default Path | Description |
+|-------------|--------------|-------------|
+| Requirements | `docs/requirement/requirements.md` | Single file with all requirements |
+| Test Specifications | `docs/test/test-specifications.md` | Single file with all test cases |
+| Multi-feature requirements | `<output_dir>/<feature>.md` | Split by feature area |
+| Index file | `<output_dir>/index.md` | Links to all feature files |
+
+**Custom output paths:**
+
+When user specifies a custom path:
+- File path: Save directly to specified location
+- Directory: Create `requirements.md` inside the directory
+- Absolute path: Use as-is (after security validation)
+
+**Output file format:**
+
+```markdown
+# Software Requirements Specification
+
+**Project:** [Project Name]
+**Standard:** ISO 29148
+**Generated:** [Date]
+**Source:** [Source file or description]
+
+---
+
+## 1. Introduction
+...
+
+## 2. Functional Requirements
+
+### REQ-001: [Requirement Title]
+
+**Description:** [What the system shall do]
+
+**Implementation:** [file.py:line]
+
+**Verification Criteria:**
+- Given [context], when [action], then [result]
+
+**Status:** [Draft|Implemented|...]
+
+---
+
+## Traceability Matrix
+
+| Requirement | Implementation | Verification | Status |
+|-------------|----------------|--------------|--------|
+| REQ-001 | file.py:45 | Unit test | Implemented |
+```
 
 ## Workflow: Create/Regenerate Setup
 

--- a/skills/req-traceability/evals/evals.json
+++ b/skills/req-traceability/evals/evals.json
@@ -49,11 +49,12 @@
       "expected_output": "Requirements extracted and saved to 'custom_docs' directory with a requirements.md file containing ISO 29148 compliant living requirements with traceability. The skill asks workflow questions interactively (one at a time), waiting for user response before showing the next question. The assertions test for final output content, not the workflow sequence.",
       "files": [],
       "assertions": [
-        "req-traceability skill",
+        "Software Requirements Specification",
         "Implementation field",
         "file:line",
         "Verification criteria",
-        "Status tracking"
+        "Status tracking",
+        "Traceability Matrix"
       ]
     },
     {
@@ -62,12 +63,13 @@
       "expected_output": "Multiple Markdown files organized by feature areas with an index.md file. Each requirement should have Implementation, Verification, and Status fields. The skill asks workflow questions interactively (one at a time), waiting for user response before showing the next question. The assertions test for final output content, not the workflow sequence.",
       "files": [],
       "assertions": [
-        "Requirements",
+        "Software Requirements Specification",
         "index.md",
         "authentication",
         "task_management",
         "Implementation",
-        "ISO 29148"
+        "ISO 29148",
+        "Traceability Matrix"
       ]
     },
     {
@@ -197,7 +199,6 @@
         "Coverage Matrix",
         "UNCOVERED_REQ",
         "Coverage: 60%",
-        "Coverage Percentage",
         "REQ-003",
         "REQ-005",
         "Test Derivation"


### PR DESCRIPTION
## Summary

- Add Output Structure section to SKILL.md with default paths, custom path handling, and output format template
- Refine eval assertions for better specificity (119 total assertions)
- Add baseline evaluation guide for future comparison

## Changes

### SKILL.md
- Added Output Structure section documenting default output locations
- Added custom output path handling documentation
- Added output file format template
- Version bump: 1.2.1 → 1.2.2

### evals.json
- Refined Eval 4 assertions: more specific output format requirements
- Refined Eval 5 assertions: added Traceability Matrix requirement
- Refined Eval 14 assertions: removed redundant assertion

## Testing

All 19 evals pass with 100% assertion coverage (119/119 assertions passed).

Closes #52